### PR TITLE
Fixed issues for World Space / Animated UIs

### DIFF
--- a/src/UI/DisplayComponents/ModTagContainer.cs
+++ b/src/UI/DisplayComponents/ModTagContainer.cs
@@ -134,8 +134,6 @@ namespace ModIO.UI
                 UnityEditor.EditorApplication.delayCall += () =>
                 {
                     GameObject displayGO = GameObject.Instantiate(tagDisplayPrefab,
-                                                                  new Vector3(),
-                                                                  Quaternion.identity,
                                                                   container);
                     displayGO.hideFlags = HideFlags.HideAndDontSave | HideFlags.HideInInspector;
 

--- a/src/UI/ExplorerTagFilterView.cs
+++ b/src/UI/ExplorerTagFilterView.cs
@@ -155,8 +155,6 @@ namespace ModIO.UI
                                                          RectTransform container)
         {
             GameObject displayGO = GameObject.Instantiate(prefab,
-                                                          new Vector3(),
-                                                          Quaternion.identity,
                                                           container);
             displayGO.name = category.name;
 

--- a/src/UI/ExplorerView.cs
+++ b/src/UI/ExplorerView.cs
@@ -512,8 +512,6 @@ namespace ModIO.UI
                     }
 
                     GameObject itemGO = GameObject.Instantiate(itemPrefab,
-                                                               new Vector3(),
-                                                               Quaternion.identity,
                                                                pageTransform);
                     itemGO.name = "Mod Tile [" + pageModViews.Count.ToString() + "]";
 

--- a/src/UI/SubscriptionsView.cs
+++ b/src/UI/SubscriptionsView.cs
@@ -175,8 +175,6 @@ namespace ModIO.UI
             {
                 // create GameObject
                 GameObject viewGO = GameObject.Instantiate(itemPrefab,
-                                                           new Vector3(),
-                                                           Quaternion.identity,
                                                            scrollView.content);
                 ModView view = viewGO.GetComponent<ModView>();
 

--- a/src/UI/Utility/ClickOffCatcher.cs
+++ b/src/UI/Utility/ClickOffCatcher.cs
@@ -110,6 +110,9 @@ namespace ModIO.UI
             // setup transform
             RectTransform cocRT = cocGO.GetComponent<RectTransform>();
             cocRT.SetParent(canvas.transform);
+            cocRT.localPosition = Vector3.zero;
+            cocRT.localRotation = Quaternion.identity;
+            cocRT.localScale = Vector3.one;
             cocRT.anchorMin = Vector2.zero;
             cocRT.anchorMax = Vector2.one;
             cocRT.offsetMin = cocRT.offsetMax = Vector2.zero;


### PR DESCRIPTION
Passing position and rotation into Instantiate uses *world* position/rotation, so this only works when the UI is at origin / not animated. With an animated world space UI, the problem with passing those in is that the new UI elements end up being offset (position/rotation) from the main UI and either float in space or are behind the camera.

With ClickOffCatcher, position, rotation and scale had to be set correctly (to local zero/identity/one).