### PR TITLE
Fixes for ModBrowser in non-active scenes

### DIFF
--- a/src/UI/ModBrowser.cs
+++ b/src/UI/ModBrowser.cs
@@ -199,7 +199,7 @@ namespace ModIO.UI
                 m_gameProfile.id = PluginSettings.data.gameId;
             }
 
-            IEnumerable<IGameProfileUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IGameProfileUpdateReceiver>(true);
+            IEnumerable<IGameProfileUpdateReceiver> updateReceivers = GetComponentsInChildren<IGameProfileUpdateReceiver>(true);
             foreach(var receiver in updateReceivers)
             {
                 receiver.OnGameProfileUpdated(m_gameProfile);
@@ -258,7 +258,7 @@ namespace ModIO.UI
                     {
                         CacheClient.SaveUserProfile(u);
 
-                        IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IAuthenticatedUserUpdateReceiver>(true);
+                        IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = GetComponentsInChildren<IAuthenticatedUserUpdateReceiver>(true);
                         foreach(var receiver in updateReceivers)
                         {
                             receiver.OnUserProfileUpdated(u);
@@ -283,7 +283,7 @@ namespace ModIO.UI
                     {
                         CacheClient.SaveUserProfile(u);
 
-                        IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IAuthenticatedUserUpdateReceiver>(true);
+                        IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = GetComponentsInChildren<IAuthenticatedUserUpdateReceiver>(true);
                         foreach(var receiver in updateReceivers)
                         {
                             receiver.OnUserProfileUpdated(u);
@@ -334,7 +334,7 @@ namespace ModIO.UI
                 {
                     m_gameProfile = g;
 
-                    IEnumerable<IGameProfileUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IGameProfileUpdateReceiver>(true);
+                    IEnumerable<IGameProfileUpdateReceiver> updateReceivers = GetComponentsInChildren<IGameProfileUpdateReceiver>(true);
                     foreach(var receiver in updateReceivers)
                     {
                         receiver.OnGameProfileUpdated(g);
@@ -428,7 +428,7 @@ namespace ModIO.UI
                         data.userId = u.id;
                         UserAuthenticationData.instance = data;
 
-                        IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IAuthenticatedUserUpdateReceiver>(true);
+                        IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = GetComponentsInChildren<IAuthenticatedUserUpdateReceiver>(true);
                         foreach(var receiver in updateReceivers)
                         {
                             receiver.OnUserProfileUpdated(u);
@@ -1674,7 +1674,7 @@ namespace ModIO.UI
             UserAuthenticationData.Clear();
 
             // - notify receivers -
-            IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IAuthenticatedUserUpdateReceiver>(true);
+            IEnumerable<IAuthenticatedUserUpdateReceiver> updateReceivers = GetComponentsInChildren<IAuthenticatedUserUpdateReceiver>(true);
             foreach(var receiver in updateReceivers)
             {
                 receiver.OnUserLoggedOut();
@@ -1865,7 +1865,7 @@ namespace ModIO.UI
             if(addedSubscriptions == null)  { addedSubscriptions = new int[0]; }
             if(removedSubscriptions == null){ removedSubscriptions = new int[0]; }
 
-            IEnumerable<IModSubscriptionsUpdateReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IModSubscriptionsUpdateReceiver>(true);
+            IEnumerable<IModSubscriptionsUpdateReceiver> updateReceivers = GetComponentsInChildren<IModSubscriptionsUpdateReceiver>(true);
             foreach(var receiver in updateReceivers)
             {
                 receiver.OnModSubscriptionsUpdated(addedSubscriptions,
@@ -1882,7 +1882,7 @@ namespace ModIO.UI
                 ModManager.SetEnabledModIds(mods);
             }
 
-            IEnumerable<IModEnabledReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IModEnabledReceiver>(true);
+            IEnumerable<IModEnabledReceiver> updateReceivers = GetComponentsInChildren<IModEnabledReceiver>(true);
             foreach(var receiver in updateReceivers)
             {
                 receiver.OnModEnabled(modId);
@@ -1898,7 +1898,7 @@ namespace ModIO.UI
                 ModManager.SetEnabledModIds(mods);
             }
 
-            IEnumerable<IModDisabledReceiver> updateReceivers = UIUtilities.FindComponentsInScene<IModDisabledReceiver>(true);
+            IEnumerable<IModDisabledReceiver> updateReceivers = GetComponentsInChildren<IModDisabledReceiver>(true);
             foreach(var receiver in updateReceivers)
             {
                 receiver.OnModDisabled(modId);
@@ -1919,7 +1919,7 @@ namespace ModIO.UI
                 ModRatingValue oldRating = this.GetModRating(modId);
 
                 // notify receivers
-                IEnumerable<IModRatingAddedReceiver> ratingReceivers = UIUtilities.FindComponentsInScene<IModRatingAddedReceiver>(true);
+                IEnumerable<IModRatingAddedReceiver> ratingReceivers = GetComponentsInChildren<IModRatingAddedReceiver>(true);
                 foreach(var receiver in ratingReceivers)
                 {
                     receiver.OnModRatingAdded(modId, ratingValue);

--- a/src/UI/Utility/UIUtilities.cs
+++ b/src/UI/Utility/UIUtilities.cs
@@ -137,6 +137,14 @@ namespace ModIO.UI
         public static T FindComponentInScene<T>(bool includeInactive)
         where T : class
         {
+            /*
+             * JC (2019-09-07): UIs are sometimes managed in their own scenes
+             * (e.g. one scene per UI panel/screen), and those scenes will usually
+             * not be the active scenes. For the purpose of resolving a singleton
+             * instance, Resources.FindObjectsOfTypeAll<T>() is probably the safer
+             * approach (Object.FindObjectOfType(type) would be more efficient but
+             * cannot return inactive objects.
+             */ 
             var activeScene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
             IEnumerable<GameObject> rootObjects = activeScene.GetRootGameObjects();
             T foundComponent = null;
@@ -167,6 +175,7 @@ namespace ModIO.UI
         public static List<T> FindComponentsInScene<T>(bool includeInactive)
         where T : class
         {
+            // JC (2019-09-07): See comment above (FindComponentInScene).
             var activeScene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
             IEnumerable<GameObject> rootObjects = activeScene.GetRootGameObjects();
             List<T> retVal = new List<T>();

--- a/src/UI/ViewManager.cs
+++ b/src/UI/ViewManager.cs
@@ -60,10 +60,10 @@ namespace ModIO.UI
         {
             if(this.m_viewsFound) { return; }
 
-            this.m_explorerView = UIUtilities.FindComponentInScene<ExplorerView>(true);
-            this.m_subscriptionsView = UIUtilities.FindComponentInScene<SubscriptionsView>(true);
-            this.m_inspectorView = UIUtilities.FindComponentInScene<InspectorView>(true);
-            this.m_loginDialog = UIUtilities.FindComponentInScene<LoginDialog>(true);
+            this.m_explorerView = GetComponentInChildren<ExplorerView>(true);
+            this.m_subscriptionsView = GetComponentInChildren<SubscriptionsView>(true);
+            this.m_inspectorView = GetComponentInChildren<InspectorView>(true);
+            this.m_loginDialog = GetComponentInChildren<LoginDialog>(true); 
             this.m_viewsFound = true;
         }
 


### PR DESCRIPTION
ModBrowser and ViewManager used UIUtilities.FindComponentInScene or FindComponentInScenes instead of GetComponent[s]InChildren. The problem with this, aside of significant performance impact, is that it only looks in the active scene but UIs may be loaded additionally as separate scenes, so this can easily break. The objects ModBrowser and ViewManager look for are currently children, so GetComponent[s]InChildren<T>() works (and is much more efficient). Otherwise, you may want to consider using Resources.FindObjectsOfTypeAll<T>().

This changeset does not replace the singleton lookups, where the same issue applies. With those, however, the current approach is really just a fallback, so it's much less critical.