### PR TITLE
For SteamVR projects, show Desktop view before opening URLs

### DIFF
--- a/src/UI/AccountOptionsMenu.cs
+++ b/src/UI/AccountOptionsMenu.cs
@@ -88,6 +88,9 @@ namespace ModIO.UI
                             profileURL += "?ref=steam";
                         }
 
+#if STEAM_VR
+                        Valve.VR.OpenVR.Overlay.ShowDashboard("valve.steam.desktop");      
+#endif
                         Application.OpenURL(profileURL);
                         this.viewProfileButton.interactable = true;
                     }

--- a/src/UI/Utility/UIUtilities.cs
+++ b/src/UI/Utility/UIUtilities.cs
@@ -77,6 +77,9 @@ namespace ModIO.UI
         {
             if(!String.IsNullOrEmpty(youTubeVideoId))
             {
+#if STEAM_VR
+                Valve.VR.OpenVR.Overlay.ShowDashboard("valve.steam.desktop");      
+#endif
                 Application.OpenURL(@"https://youtu.be/" + youTubeVideoId);
             }
         }

--- a/src/UI/Utility/WebLinkFollower.cs
+++ b/src/UI/Utility/WebLinkFollower.cs
@@ -6,6 +6,9 @@ namespace ModIO.UI
     {
         public void OpenBrowserAt(string url)
         {
+#if STEAM_VR
+            Valve.VR.OpenVR.Overlay.ShowDashboard("valve.steam.desktop");      
+#endif
             Application.OpenURL(url);
         }
     }


### PR DESCRIPTION
SteamVR has an API call that shows the Steam Desktop in VR, so when a URL is opened in a browser, the player actually can see that. This obviously requires that SteamVR is available to the mod.io plugin. By encapsulating the code so that it's only compiled when the STEAM_VR conditional compilation symbol is set, it doesn't break anything if SteamVR is not available (but obviously also only has an effect when that symbol is set).