### PR TITLE
Restored ClearFilters() because it is still used in the UI

### DIFF
--- a/src/UI/ExplorerView.cs
+++ b/src/UI/ExplorerView.cs
@@ -710,6 +710,12 @@ namespace ModIO.UI
             }
         }
 
+        [Obsolete("Replaced by ClearAllFilters() - but still used in ModBrowser (prefab), ClearFilterButton")]
+        public void ClearFilters()
+        {
+            ClearAllFilters();
+        }
+        
         // ---------[ FILTER MANAGEMENT ]---------
         public void ClearAllFilters()
         {


### PR DESCRIPTION
The button _ModBrowser / MainContainer+Mask / ExplorerView / MainPanel / NoResults / ClearFilterButton didn't work. The reason is probably due to a refactoring where ClearFilters() was renamed to ClearAllFilters(), so the event link broke. I have (re-)added ClearFilters() and marked it as obsolete. Alternatively, the prefab could be changed to use the new method.