### PR TITLE
Make changing PluginSettings from build scripts possible

### DIFF
--- a/src/PluginSettings.cs
+++ b/src/PluginSettings.cs
@@ -8,7 +8,7 @@ namespace ModIO
         // ---------[ NESTED CLASSES ]---------
         /// <summary>Data struct that is wrapped by the ScriptableObject.</summary>
         [System.Serializable]
-        public struct Data
+        public class Data
         {
             // ---------[ FIELDS ]---------
             [Tooltip("API URL to use when making requests")]
@@ -62,6 +62,7 @@ namespace ModIO
         #pragma warning disable 0649
         private Data m_data;
         #pragma warning restore 0649
+        public Data InstanceData => m_data;
 
         // ---------[ FUNCTIONALITY ]---------
         /// <summary>Loads the Data from the asset instance.</summary>


### PR DESCRIPTION
This is a quick fix for enabling changes to PluginSettings from build scripts. The issue was that Data is a struct only accessible via a static getter; so there was no way to change the values from code, which is a requirement in our project because we have multiple games in the same project and simply use different build scripts for the different games.

This does not fix the issue that we need to duplicate the code to load PluginSettings from the resources. It would be preferable to get the PluginSettings singleton-style instead of using it as just a wrapper for data; so instead of writing PluginSettings.data, it would be PluginSettings.Instance.data. That way, the PluginSettings asset could be loaded and marked easily as dirty for the assets database.

This mostly fixes https://github.com/modio/UnityPlugin/issues/21