### PR TITLE
Made PluginSettings path keyword replacement more safe

### DIFF
--- a/src/CacheClient.cs
+++ b/src/CacheClient.cs
@@ -22,7 +22,7 @@ namespace ModIO
         static CacheClient()
         {
             PluginSettings.Data settings = PluginSettings.data;
-            CacheClient.cacheDirectory = settings.cacheDirectory;
+            CacheClient.cacheDirectory = settings.CacheDirectory;
         }
 
         // ---------[ GAME PROFILE ]---------

--- a/src/ModManager.cs
+++ b/src/ModManager.cs
@@ -51,8 +51,8 @@ namespace ModIO
         static ModManager()
         {
             PluginSettings.Data settings = PluginSettings.data;
-            ModManager.installationDirectory = settings.installationDirectory;
-            ModManager.PERSISTENTDATA_FILEPATH = IOUtilities.CombinePath(settings.cacheDirectory, PERSISTENTDATA_FILENAME);
+            ModManager.installationDirectory = settings.InstallationDirectory;
+            ModManager.PERSISTENTDATA_FILEPATH = IOUtilities.CombinePath(settings.CacheDirectory, PERSISTENTDATA_FILENAME);
 
             if(!IOUtilities.TryReadJsonObjectFile(PERSISTENTDATA_FILEPATH, out ModManager.m_data))
             {

--- a/src/UI/ModBrowser.cs
+++ b/src/UI/ModBrowser.cs
@@ -161,7 +161,7 @@ namespace ModIO.UI
                 this.gameObject.SetActive(false);
                 return;
             }
-            if(String.IsNullOrEmpty(settings.cacheDirectory))
+            if(String.IsNullOrEmpty(settings.CacheDirectory))
             {
                 Debug.LogError("[mod.io] Cache Directory is missing from the Plugin Settings.\n"
                                + "This must be configured by selecting the mod.io > Edit Settings menu"
@@ -172,7 +172,7 @@ namespace ModIO.UI
                 this.gameObject.SetActive(false);
                 return;
             }
-            if(String.IsNullOrEmpty(settings.installationDirectory))
+            if(String.IsNullOrEmpty(settings.InstallationDirectory))
             {
                 Debug.LogError("[mod.io] Mod Installation Directory is missing from the Plugin Settings.\n"
                                + "This must be configured by selecting the mod.io > Edit Settings menu"

--- a/src/UserAuthenticationData.cs
+++ b/src/UserAuthenticationData.cs
@@ -21,7 +21,7 @@ namespace ModIO
         };
 
         /// <summary>Location of the settings file.</summary>
-        public static readonly string FILE_LOCATION = IOUtilities.CombinePath(PluginSettings.data.cacheDirectory,
+        public static readonly string FILE_LOCATION = IOUtilities.CombinePath(PluginSettings.data.CacheDirectory,
                                                                               "user.data");
 
         // ---------[ FIELDS ]---------


### PR DESCRIPTION
The problem with replacing the keywords on load is that this results in the keywords being persistently replaced when using the new SetGlobalValues(...) workflow for changing the settings during build time.

The approach suggested by this Pull request handles the keyword replacement by making the serialized members private, and doing the keyword replacement the first time the public property getter is called. This way, the persistent member variables are never altered and the final path will never be (accidentally) stored.

One additional benefit is that using Properties for these two values makes it obvious that the value received when getting the property may be different from the serialized member variable (because property getters are methods, so some processing can occur).

While at it, I also replaced the duplicate keyword replacement code with a single method.