### PR TITLE
Updated obsolete authentication state checks

### DIFF
--- a/Runtime/ModManager.cs
+++ b/Runtime/ModManager.cs
@@ -1783,7 +1783,7 @@ namespace ModIO
                                                        Action<WebRequestError> onError)
         {
             if(LocalUser.Profile == null
-               && !string.IsNullOrEmpty(LocalUser.OAuthToken))
+               && LocalUser.AuthenticationState == AuthenticationState.ValidToken)
             {
                 UserAccountManagement.UpdateUserProfile(onSuccess, onError);
             }

--- a/Runtime/UI/ModBrowser.cs
+++ b/Runtime/UI/ModBrowser.cs
@@ -205,7 +205,7 @@ namespace ModIO.UI
                     int reattemptDelay = CalculateReattemptDelay(requestError);
                     if(requestError.isAuthenticationInvalid)
                     {
-                        if(string.IsNullOrEmpty(LocalUser.OAuthToken))
+                        if(LocalUser.AuthenticationState == AuthenticationState.NoToken)
                         {
                             Debug.LogWarning("[mod.io] Unable to retrieve the game profile from the mod.io"
                                              + " servers. Please check you Game Id and APIKey in the"

--- a/Runtime/UI/User/AccountReactiveButton.cs
+++ b/Runtime/UI/User/AccountReactiveButton.cs
@@ -28,9 +28,7 @@ namespace ModIO.UI
         // ---------[ EVENTS ]---------
         private void OnButtonClick()
         {
-            bool loggedIn = !string.IsNullOrEmpty(LocalUser.OAuthToken);
-
-            if(!loggedIn)
+            if(LocalUser.AuthenticationState != AuthenticationState.ValidToken)
             {
                 if(onLoggedOutClick != null)
                 {


### PR DESCRIPTION
Updated some obsolete authentication state checks that used string.IsEmpty instead of LocalUser.AuthState